### PR TITLE
Running processes could prevent unmounting. Kill.them.

### DIFF
--- a/reset-state
+++ b/reset-state
@@ -46,7 +46,14 @@ echo "Unmounting all snaps..."
 echo
 (
     set -x
-    umount /var/lib/snapd/snaps/*.snap
+    if which lsof &>/dev/null; then
+        lsof -t -x f +D /snap |while read p; do kill $p; seq 30 |while read; do sleep 1; kill -0 $p || break; done; done
+    fi
+    umount /var/lib/snapd/snaps/*.snap || {
+        set +x
+        which lsof &>/dev/null || echo "Install 'lsof', and this script could kill programs that prevent unmounting snap files."
+        exit 1
+    }
 )
 
 echo


### PR DESCRIPTION
If the user has "lsof" installed, we can discover processes that will stop the umount step from succeeding, and kill those processes. We wait a reasonable time for them to quit, before we try umount anyway.